### PR TITLE
feat: include http-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lamprox",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Framework for development lambda-proxy function of AWS Lambda.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "mocha --compilers ts:espower-typescript/guess test/**/*.ts"
+    "test": "mocha --compilers ts:espower-typescript/guess \"test/**/*.ts\""
   },
   "repository": {
     "type": "git",
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/AKIRA-MIYAKE/lamprox#readme",
   "devDependencies": {
+    "@types/http-errors": "^1.6.1",
     "@types/mocha": "^2.2.42",
     "@types/power-assert": "^1.4.29",
     "@types/sinon": "^2.3.3",
@@ -34,6 +35,7 @@
   },
   "dependencies": {
     "@types/node": "^8.0.25",
+    "http-errors": "^1.6.2",
     "lambda-utilities": "0.0.2"
   }
 }

--- a/src/processes/after-process.ts
+++ b/src/processes/after-process.ts
@@ -1,0 +1,4 @@
+import { AfterProcess } from '../types'
+
+export const getDefaultAfterProcess: <U, E>() => AfterProcess<U, E>
+= <U, E>() => ambience => Promise.resolve(ambience.result)

--- a/src/processes/before-process.ts
+++ b/src/processes/before-process.ts
@@ -1,0 +1,4 @@
+import { BeforeProcess } from '../types'
+
+export const getDefaultBeforeProcess: <T, E>() => BeforeProcess<T, E>
+= <T, E>() => ambience => Promise.resolve(undefined)

--- a/src/processes/index.ts
+++ b/src/processes/index.ts
@@ -1,41 +1,4 @@
-import {
-  BeforeProcess,
-  AfterProcess,
-  ResponseProcess,
-  OnErrorProcess,
-  ProcessAmbience
-} from '../types'
-
-export const getDefaultBeforeProcess: <T, E>() => BeforeProcess<T, E>
-= <T, E>() => ambience => Promise.resolve(undefined)
-
-export const getDefaultAfterProcess: <U, E>() => AfterProcess<U, E>
-= <U, E>() => ambience => Promise.resolve(ambience.result)
-
-export const getDefaultResponseProcess: <U, E>() => ResponseProcess<U, E>
-= <U, E>() => ambience => {
-  const result = ambience.result
-
-  const body = (typeof result !== 'undefined')
-    ? (typeof result !== 'string') ? JSON.stringify(result) : result
-    : ''
-
-  return Promise.resolve({
-    statusCode: 200,
-    body: body
-  })
-}
-
-export const getDefaultOnErrorProcess: <E>() => OnErrorProcess<E>
-= <E>() => ambience => {
-  const result = ambience.result
-
-  const body = (typeof result !== 'undefined')
-    ? JSON.stringify({ name: result.name, message: result.message })
-    : JSON.stringify({ name: 'FatalError', message: 'An error occurred.' })
-
-  return Promise.resolve({
-    statusCode: 500,
-    body: body
-  })
-}
+export * from './after-process'
+export * from './before-process'
+export * from './on-error-process'
+export * from './response-process'

--- a/src/processes/on-error-process.ts
+++ b/src/processes/on-error-process.ts
@@ -1,0 +1,16 @@
+import * as createHttpError from 'http-errors'
+
+import { isHttpError } from '../utilities/http-errors'
+
+import { OnErrorProcess } from '../types'
+
+export const getDefaultOnErrorProcess: <E>() => OnErrorProcess<E>
+= <E>() => ambience => {
+  const result = ambience.result
+  const error = (typeof result !== 'undefined') ? result : new createHttpError.InternalServerError()
+
+  return Promise.resolve({
+    statusCode: (isHttpError(error)) ? error.statusCode : 500,
+    body: JSON.stringify({ name: error.name, message: error.message })
+  })
+}

--- a/src/processes/response-process.ts
+++ b/src/processes/response-process.ts
@@ -1,0 +1,27 @@
+import { ProxyResult } from 'aws-lambda'
+
+import { ResponseProcess } from '../types'
+
+export const getDefaultResponseProcess: <U, E>() => ResponseProcess<U, E>
+= <U, E>() => ambience => {
+  const result = ambience.result
+
+  let headers: { [key: string]: any } = {}
+  let body: string = ''
+
+  if (typeof result !== 'undefined') {
+    if (typeof result === 'string') {
+      headers['Content-Type'] = 'text/plain'
+      body = result
+    } else {
+      headers['Content-Type'] = 'application/json'
+      body = JSON.stringify(result)
+    }
+  }
+
+  return Promise.resolve({
+    statusCode: 200,
+    headers: headers,
+    body: body
+  })
+}

--- a/src/utilities/http-errors/index.ts
+++ b/src/utilities/http-errors/index.ts
@@ -1,0 +1,14 @@
+import { HttpError } from 'http-errors'
+
+export function isHttpError(error: Error): error is HttpError {
+  const _error = error as any
+
+  if (
+    typeof _error.statusCode !== 'undefined' &&
+    typeof _error.expose !== 'undefined'
+  ) {
+    return true
+  } else {
+    return false
+  }
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,2 +1,3 @@
 export * from './api-gateway-event'
+export * from './http-errors'
 export * from './process-ambience'

--- a/test/processes/on-error-process.ts
+++ b/test/processes/on-error-process.ts
@@ -1,0 +1,126 @@
+import * as assert from 'power-assert'
+
+import * as createHttpError from 'http-errors'
+import { generateDummyContext, generateMockCallback } from 'lambda-utilities'
+
+import { generateDummyAPIGatewayEvent } from '../../src/utilities/api-gateway-event'
+import { generateProcessAmbience } from '../../src/utilities/process-ambience'
+
+import { getDefaultOnErrorProcess } from '../../src/processes'
+
+describe('processes', () => {
+
+  describe('getDefaultOnErrorProcess()', () => {
+    const process = getDefaultOnErrorProcess()
+
+    it('Should return proxy result.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new Error('Error Message'),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 500)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'Error')
+        assert.equal(body.message, 'Error Message')
+      })
+    })
+
+    it('SHoud return proxy result when bad request.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new createHttpError.BadRequest(),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 400)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'BadRequestError')
+        assert.equal(body.message, 'Bad Request')
+      })
+    })
+
+    it('SHoud return proxy result when unauthorizedt.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new createHttpError.Unauthorized(),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 401)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'UnauthorizedError')
+        assert.equal(body.message, 'Unauthorized')
+      })
+    })
+
+    it('SHoud return proxy result when forbidden.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new createHttpError.Forbidden(),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 403)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'ForbiddenError')
+        assert.equal(body.message, 'Forbidden')
+      })
+    })
+
+    it('SHoud return proxy result when not found.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new createHttpError.NotFound(),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 404)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'NotFoundError')
+        assert.equal(body.message, 'Not Found')
+      })
+    })
+
+    it('Should return proxy result internal server error.', () => {
+      const ambience = generateProcessAmbience<Error, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: new createHttpError.InternalServerError(),
+        environments: undefined,
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 500)
+        const body = JSON.parse(result.body)
+        assert.equal(body.name, 'InternalServerError')
+        assert.equal(body.message, 'Internal Server Error')
+      })
+    })
+
+  })
+
+})

--- a/test/processes/response-process.ts
+++ b/test/processes/response-process.ts
@@ -1,0 +1,81 @@
+import * as assert from 'power-assert'
+
+import { generateDummyContext, generateMockCallback } from 'lambda-utilities'
+
+import { generateDummyAPIGatewayEvent } from '../../src/utilities/api-gateway-event'
+import { generateProcessAmbience } from '../../src/utilities/process-ambience'
+
+import { getDefaultResponseProcess } from '../../src/processes'
+
+describe('processes', () => {
+
+  describe('getDefaultResponseProcess', () => {
+
+    it('Should return proxy result when input result is string.', () => {
+      const process = getDefaultResponseProcess<string, undefined>()
+      const ambience = generateProcessAmbience<string, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: 'This is a result string.',
+        environments: undefined
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 200)
+        assert.equal(result.headers['Content-Type'], 'text/plain')
+        assert.equal(result.body, 'This is a result string.')
+      })
+    })
+
+    it('Should return proxy result when input result is object.', () => {
+      interface Result {
+        foo: number,
+        bar: string
+      }
+
+      const process = getDefaultResponseProcess<Result, undefined>()
+      const ambience = generateProcessAmbience<Result, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: { foo: 42, bar: 'banana' },
+        environments: undefined
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 200)
+        assert.equal(result.headers['Content-Type'], 'application/json')
+        const body = JSON.parse(result.body)
+        assert.equal(body.foo, 42)
+        assert.equal(body.bar, 'banana')
+      })
+    })
+
+    it('Should return proxy result when input result is undefined.', () => {
+      interface Result {
+        foo: number,
+        bar: string
+      }
+
+      const process = getDefaultResponseProcess<Result, undefined>()
+      const ambience = generateProcessAmbience<Result, undefined>({
+        event: generateDummyAPIGatewayEvent(),
+        context: generateDummyContext(),
+        callback: generateMockCallback(),
+        result: undefined,
+        environments: undefined
+      })
+
+      return process(ambience)
+      .then(result => {
+        assert.equal(result.statusCode, 200)
+        assert.equal(result.body, '')
+      })
+    })
+
+  })
+
+})

--- a/test/utilities/http-error/index.ts
+++ b/test/utilities/http-error/index.ts
@@ -1,0 +1,22 @@
+import * as assert from 'power-assert'
+
+import * as createHttpError from 'http-errors'
+
+import { isHttpError } from '../../../src/utilities/http-errors'
+
+describe('utilities/http-error', () => {
+
+  describe('isHttpError()', () => {
+
+    it('Should be able to discriminate.', () => {
+      assert.ok(isHttpError(new createHttpError.BadRequest()))
+      assert.ok(isHttpError(new createHttpError.Unauthorized()))
+      assert.ok(isHttpError(new createHttpError.Forbidden()))
+      assert.ok(isHttpError(new createHttpError.NotFound()))
+      assert.ok(isHttpError(new createHttpError.InternalServerError()))
+      assert.ok(!isHttpError(new Error()))
+    })
+
+  })
+
+})


### PR DESCRIPTION
Added a function to determine the status code of onErrorProcess depending on the type of httpError.